### PR TITLE
Improve main.py dependency handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,9 +5,28 @@ SGPS – Bullet‑proof Llama pretraining_tp patch
 """
 
 # ─── 기본 import ───
-import argparse, random, json, time, re
+import argparse, random, json, time, re, sys, importlib.util
 from pathlib import Path
 from typing import List
+
+REQUIRED_PKGS = ["numpy", "torch", "evaluate", "detoxify",
+                 "datasets", "transformers", "bitsandbytes"]
+
+def check_requirements():
+    missing = []
+    for name in REQUIRED_PKGS:
+        if importlib.util.find_spec(name) is None:
+            missing.append(name)
+    if missing:
+        sys.stderr.write(
+            "Missing required packages: {}\n".format(", ".join(missing)))
+        sys.stderr.write("Please install dependencies listed in requirements.txt\n")
+        return False
+    return True
+
+if not check_requirements():
+    sys.exit(1)
+
 import numpy as np
 from tqdm.auto import tqdm
 from loguru import logger


### PR DESCRIPTION
## Summary
- add dependency check to `main.py`
- exit early with a helpful message when required packages are missing

## Testing
- `python -m py_compile main.py`
- `python main.py > /tmp/main_run.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_685690f95ed4832c955e064484d1b880